### PR TITLE
upgrade auth0 package version

### DIFF
--- a/RegularWebApp/lib/routes/user.js
+++ b/RegularWebApp/lib/routes/user.js
@@ -6,8 +6,10 @@ const express = require('express');
 const router = express.Router();
 const _ = require('lodash');
 
-const auth0 = require('auth0')({
-  token: process.env.AUTH0_APIV2_TOKEN
+const ManagementClient = require('auth0').ManagementClient
+const management = new ManagementClient({
+  token: process.env.AUTH0_APIV2_TOKEN,
+  domain: process.env.AUTH0_DOMAIN
 });
 
 /*
@@ -26,8 +28,8 @@ function _mergeMetadata(primaryUser, secondaryUser){
   const mergedAppMetadata = _.merge({}, secondaryUser.app_metadata, primaryUser.app_metadata, customizerCallback);
   
   return Promise.all([
-    auth0.users.updateUserMetadata(primaryUser.user_id, mergedUserMetadata),
-    auth0.users.updateAppMetadata(primaryUser.user_id, mergedAppMetadata)
+    management.users.updateUserMetadata({ id: primaryUser.user_id }, mergedUserMetadata),
+    management.users.updateAppMetadata({ id: primaryUser.user_id }, mergedAppMetadata)
   ]).then(result => {
     //save result in primary in session
     primaryUser.user_metadata = result[0].user_metadata;

--- a/RegularWebApp/package.json
+++ b/RegularWebApp/package.json
@@ -9,7 +9,7 @@
     "start": "node ./bin/www"
   },
   "dependencies": {
-    "auth0": "^2.0.0-alpha.5",
+    "auth0": "^2.6.0",
     "body-parser": "~1.13.2",
     "connect-ensure-login": "^0.1.1",
     "cookie-parser": "~1.3.5",


### PR DESCRIPTION
This fixes Issue #2 as well as well as brings the auth0 package used beyond the alpha version.

Because NPM has indeterminate version installs, when doing a fresh clone and running `npm install`, the code will not work. Node will be running a newer version of of the auth0 package which is not compatible with alpha version code.