### PR TITLE
Fixed misleading id_token error in SPA app

### DIFF
--- a/SPA/app.js
+++ b/SPA/app.js
@@ -273,6 +273,8 @@ $(document).ready(function() {
     }
   } else {
     //handle case of already logged-in user
-    reloadProfile();
+    if(localStorage.getItem('id_token') !== null) {
+      reloadProfile();
+    }
   }
 });


### PR DESCRIPTION
An error occurs when you run the SPA app for the first time or with a clean session. It's caused by the app attempting to reload the profile while id_token is missing from local storage. 

This PR addresses the issue by ensuring id_token exists in local storage before reloading the profile.